### PR TITLE
TypeScript config updates

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -11,6 +11,12 @@ For adding TypeScript support to a project.
 | [`yarn add -D tslint-config-prettier`](https://yarn.pm/tslint-config-prettier)     | TypeScript config for Prettier integration |
 | [`yarn add -D typescript-tslint-plugin`](https://yarn.pm/typescript-tslint-plugin) | Integrate TSLint better into VSCode        |
 
+If you are using Webpack and Babel 7:
+
+| Package                                                                            | Description                 |
+| ---------------------------------------------------------------------------------- | --------------------------- |
+| [`yarn add -D @babel/preset-typescript`](https://yarn.pm/@babel/preset-typescript) | Babel preset for TypeScript |
+
 ## Files
 
 | File                             | Description                                                                                                         |
@@ -18,3 +24,10 @@ For adding TypeScript support to a project.
 | [tsconfig.json](./tsconfig.json) | TypeScript configuration with support for Babel, strict mode, and React. Please change `src/` in the includes path! |
 | [tslint.json](./tslint.json)     | TypeScript linter config.                                                                                           |
 | [package.json](./package.json)   | Scripts config                                                                                                      |
+
+If you're using Webpack and Babel:
+
+| File                                     | Description           |
+| ---------------------------------------- | --------------------- |
+| [webpack.config.js](./webpack.config.js) | Webpack configuration |
+| [babel.config.js](./babel.config.js)     | Babel configuration   |

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -2,6 +2,15 @@
 
 For adding TypeScript support to a project.
 
+## Packages required
+
+| Package                                                                            | Description                                |
+| ---------------------------------------------------------------------------------- | ------------------------------------------ |
+| [`yarn add -D typescript`](https://yarn.pm/typescript)                             | Main TypeScript packag                     |
+| [`yarn add -D tslint`](https://yarn.pm/tslint)                                     | TypeScript linter                          |
+| [`yarn add -D tslint-config-prettier`](https://yarn.pm/tslint-config-prettier)     | TypeScript config for Prettier integration |
+| [`yarn add -D typescript-tslint-plugin`](https://yarn.pm/typescript-tslint-plugin) | Integrate TSLint better into VSCode        |
+
 ## Files
 
 | File                             | Description                                                                                                         |
@@ -9,12 +18,3 @@ For adding TypeScript support to a project.
 | [tsconfig.json](./tsconfig.json) | TypeScript configuration with support for Babel, strict mode, and React. Please change `src/` in the includes path! |
 | [tslint.json](./tslint.json)     | TypeScript linter config.                                                                                           |
 | [package.json](./package.json)   | Scripts config                                                                                                      |
-
-## Packages required
-
-| Package                                                                            | Description                                |
-| ---------------------------------------------------------------------------------- | ------------------------------------------ |
-| `[yarn add -D typescript](https://yarn.pm/typescript)`                             | main TypeScript packag                     |
-| `[yarn add -D tslint](https://yarn.pm/tslint)`                                     | TypeScript linter                          |
-| `[yarn add -D tslint-config-prettier](https://yarn.pm/tslint-config-prettier)`     | TypeScript config for Prettier integration |
-| `[yarn add -D typescript-tslint-plugin](https://yarn.pm/typescript-tslint-plugin)` | Integrate TSLint better into VSCode        |

--- a/typescript/babel.config.js
+++ b/typescript/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    '@babel/env',
+    '@babel/typescript' /* <-- add this */
+  ]
+}

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -17,6 +17,5 @@
     "esModuleInterop": true,
     "plugins": [{ "name": "typescript-tslint-plugin" }]
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.js"]
+  "include": ["src"]
 }

--- a/typescript/tslint.json
+++ b/typescript/tslint.json
@@ -4,12 +4,15 @@
     "tslint:recommended",
     "tslint-config-prettier"
   ],
+  "jsRules": {
+    "object-literal-sort-keys": false,
+    "curly": false
+  },
   "rules": {
     "interface-name": false,
     "object-literal-sort-keys": false,
     "member-access": [true, "no-public"],
-    "curly": false,
-    "no-empty": false
+    "curly": false
   },
   "rulesDirectory": []
 }

--- a/typescript/webpack.config.js
+++ b/typescript/webpack.config.js
@@ -1,0 +1,22 @@
+// You may need to update your module rules to load `ts` and `tsx` files with Babel loader.
+// (For this to work, your Babel configuration also needs `@babel/preset-typescript`.)
+
+module.exports = {
+  /* ... */
+
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx|ts|tsx)$/,
+        exclude: /node_modules/,
+        use: [
+          { loader: 'babel-loader' }
+        ]
+      },
+
+      /* ... */
+    ]
+  }
+
+  /* ... */
+}


### PR DESCRIPTION
- Removes `no-curly: false` as proposed by Jigz. This was meant to allow for things like empty-catches, which should now not be allowed.

  ```js
  // This will now throw an error
  try {
    doSomething()
  } catch {}
  ```

- Adds jsRules

  > This will restrict tslint-config-recommended's strictness for .js files.

- Most controversially: **allows TypeScript to check .js files.**


## Why type-check JS files?

The `exclude: ['**/*.js']` rule was initially added by Jigz, but I propose that we remove it.

1. It provides (basic) types for VSCode, so you can get (basic) type inference and hints in your editor.

2. TS/TSX files using JS files will be type-checked against these basic types.

Usually checking `*.js` files will introduce type errors right away, but in most cases, these can be resolved by including the appropriate 3rd-party types. For example, a React project may have React type errors, and it's remedied by simply doing `yarn add -D @types/react{,-dom}`.

## Related topics

See: https://github.com/mashupgarage/playbook/pull/354